### PR TITLE
fix(connections): correct display order of chains column

### DIFF
--- a/src/components/connections.rs
+++ b/src/components/connections.rs
@@ -154,7 +154,11 @@ pub static CONNECTION_COLS: &[ColDef<Connection>] = &[
         title: "Chains",
         filterable: true,
         sortable: true,
-        accessor: |c: &Connection| Cow::Owned(c.chains.join(" > ")),
+        accessor: |c: &Connection| {
+            // Reverse to display in correct order
+            let chains: Vec<&str> = c.chains.iter().rev().map(String::as_str).collect();
+            Cow::Owned(chains.join(" > "))
+        },
         sort_key: None,
     },
     ColDef {


### PR DESCRIPTION
Currently, the chains column in the Connections component displays the proxy chain path in reverse order.

This PR modifies the accessor in src/components/connections.rs to reverse the sequence before display. This ensures the chain is shown in the correct order (e.g., Selector > ... > Actual Node) within the TUI.