### PR TITLE
fix(store): resolve provider-sourced nodes in group details

### DIFF
--- a/src/store/proxies.rs
+++ b/src/store/proxies.rs
@@ -9,6 +9,7 @@ use tracing::{debug, error, info, warn};
 use crate::api::Api;
 use crate::config::{LatencyThreshold, ProxySortConfig};
 use crate::models::proxy::Proxy;
+use crate::models::proxy_provider::ProxyProvider;
 use crate::models::sort::{ProxySortField, SortDir};
 use crate::store::proxy_setting::ProxySetting;
 use crate::widgets::latency::{LatencyQuality, QualityStats};
@@ -89,15 +90,20 @@ impl Proxies {
 
     /// Load proxies from API and update the store.
     pub async fn load(api: Arc<Api>) -> Result<()> {
-        match api.get_proxies().await {
-            Ok(proxies) => {
-                debug!("Proxies loaded");
-                match Self::global().write() {
-                    Ok(mut p) => p.push(proxies),
-                    Err(e) => error!(error = ?e, "Failed to acquire write lock"),
-                }
-            }
-            Err(e) => return Err(e),
+        // `GET /proxies` only contains groups and proxies defined inline in the
+        // core config; nodes sourced from proxy providers are only exposed via
+        // `GET /providers/proxies`. Merge them in so group children referencing
+        // provider nodes can be resolved by name.
+        let (proxies, providers) = tokio::join!(api.get_proxies(), api.get_providers());
+        let mut proxies = proxies?;
+        match providers {
+            Ok(providers) => Self::merge_provider_proxies(&mut proxies, providers),
+            Err(e) => warn!(error = ?e, "Failed to load providers, provider nodes may be missing"),
+        }
+        debug!("Proxies loaded");
+        match Self::global().write() {
+            Ok(mut p) => p.push(proxies),
+            Err(e) => error!(error = ?e, "Failed to acquire write lock"),
         }
 
         Ok(())
@@ -313,13 +319,27 @@ impl Proxies {
         }
     }
 
+    /// Merge provider-sourced proxies into the map. Entries already present in
+    /// `GET /proxies` (groups, inline proxies) take precedence; "Compatible"
+    /// providers mirroring groups are therefore effectively ignored.
+    fn merge_provider_proxies(
+        proxies: &mut IndexMap<String, Proxy>,
+        providers: IndexMap<String, ProxyProvider>,
+    ) {
+        for provider in providers.into_values() {
+            for proxy in provider.proxies {
+                proxies.entry(proxy.name.clone()).or_insert(proxy);
+            }
+        }
+    }
+
     fn remove_missing_children(proxies: &mut IndexMap<String, Proxy>) {
         let keys: HashSet<_> = proxies.keys().cloned().collect();
         for v in proxies.values_mut() {
             if let Some(children) = v.children.as_mut() {
                 let missing: Vec<_> = children.iter().filter(|c| !keys.contains(*c)).collect();
                 if missing.is_empty() {
-                    return;
+                    continue;
                 }
                 warn!("Proxy '{}' has missing children: {:?}", v.name, missing);
                 children.retain(|c| keys.contains(c));
@@ -378,6 +398,49 @@ mod tests {
 
     fn sort_config(field: ProxySortField, dir: SortDir) -> ProxySortConfig {
         ProxySortConfig { field, dir }
+    }
+
+    #[test]
+    fn test_merge_provider_proxies_adds_nodes_and_keeps_existing() {
+        let mut proxies = IndexMap::from([
+            ("group".to_string(), proxy("group", Some(vec!["a", "b"]), None)),
+            ("a".to_string(), proxy("a", None, Some(10))),
+        ]);
+        let providers = IndexMap::from([(
+            "p1".to_string(),
+            ProxyProvider {
+                name: "p1".to_string(),
+                vehicle_type: "HTTP".to_string(),
+                proxies: vec![proxy("a", None, Some(999)), proxy("b", None, Some(20))],
+                subscription_info: None,
+                updated_at: None,
+                updated_at_str: None,
+            },
+        )]);
+
+        Proxies::merge_provider_proxies(&mut proxies, providers);
+
+        assert_eq!(proxies.len(), 3);
+        // existing entry from `/proxies` wins over the provider copy
+        assert_eq!(proxies.get("a").unwrap().latency.0, Some(10));
+        assert_eq!(proxies.get("b").unwrap().latency.0, Some(20));
+    }
+
+    #[test]
+    fn test_remove_missing_children_cleans_all_groups() {
+        let mut proxies = IndexMap::from([
+            ("ok".to_string(), proxy("ok", Some(vec!["a"]), None)),
+            ("broken".to_string(), proxy("broken", Some(vec!["a", "ghost"]), None)),
+            ("a".to_string(), proxy("a", None, Some(10))),
+        ]);
+
+        Proxies::remove_missing_children(&mut proxies);
+
+        // groups after the first clean one must still be processed
+        assert_eq!(
+            proxies.get("broken").and_then(|p| p.children.clone()).unwrap(),
+            vec!["a".to_string()]
+        );
     }
 
     #[test]

--- a/src/widgets/latency.rs
+++ b/src/widgets/latency.rs
@@ -108,6 +108,10 @@ impl QualityStats {
     }
 
     pub fn as_line<'a>(&self, width: u16, total: usize) -> Line<'a> {
+        // `total == 0` would make `exact` NaN below and panic in the comparator
+        if total == 0 {
+            return Line::default();
+        }
         let mut segments: Vec<(u16, f64)> = self
             .0
             .iter()
@@ -118,7 +122,10 @@ impl QualityStats {
             .collect();
 
         for _ in 0..width.saturating_sub(segments.iter().map(|(n, _)| *n).sum::<u16>()) {
-            let seg = segments.iter_mut().max_by(|a, b| a.1.partial_cmp(&b.1).unwrap()).unwrap();
+            let seg = segments
+                .iter_mut()
+                .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
+                .unwrap();
 
             seg.0 += 1;
             seg.1 = 0.0;
@@ -134,5 +141,22 @@ impl QualityStats {
                 )
             })
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_as_line_with_zero_total_does_not_panic() {
+        let line = QualityStats::new([0; LatencyQuality::COUNT]).as_line(10, 0);
+        assert_eq!(line.width(), 0);
+    }
+
+    #[test]
+    fn test_as_line_fills_width() {
+        let line = QualityStats::new([1, 1, 1, 0]).as_line(90, 3);
+        assert_eq!(line.width(), 90);
     }
 }


### PR DESCRIPTION
## Problem

When nodes come from `proxy-providers` (the common subscription setup), the proxy-detail popup only shows child *groups* — all provider-sourced nodes are missing. For a group with 138 children, only the 4 nested groups were rendered.

## Root cause

mihomo's `GET /proxies` only returns proxy groups and proxies defined inline in the core config. Nodes sourced from proxy providers are only exposed via `GET /providers/proxies`. The store builds its name map from `/proxies` alone, so `Proxies::with_by_names` silently drops every child name that belongs to a provider node. (Official dashboards like metacubexd resolve group members by merging `/providers/proxies` for the same reason.)

## Fix

- `Proxies::load` now fetches `/proxies` and `/providers/proxies` concurrently and merges provider proxies into the map. Existing `/proxies` entries take precedence, so the group-mirroring "Compatible" providers are effectively ignored. A provider fetch failure degrades gracefully (warn + previous behavior).
- Fixed an early `return` in `remove_missing_children` that stopped cleaning the remaining groups as soon as one group had no missing children.
- Fixed a panic in `QualityStats::as_line` when `total == 0`: the division produces NaN fractions and `partial_cmp(...).unwrap()` panics (`panicked at src/widgets/latency.rs:121:79: called Option::unwrap() on a None value`).

## Testing

- `cargo test` — 118 passed (4 new unit tests covering the merge, the cleanup loop, and the zero-total panic).
- Verified against a live mihomo 1.19.29 with 3 HTTP providers (134 nodes): before the patch the detail popup showed only 4 nested groups; after, all 138 children render with type and latency, and the latency distribution bars on group cards are populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
